### PR TITLE
Fixed exception on startup when list of profiles is null - issue #225

### DIFF
--- a/ScpProfiler/MainWindow.xaml.cs
+++ b/ScpProfiler/MainWindow.xaml.cs
@@ -33,7 +33,15 @@ namespace ScpProfiler
 
             MainGrid.DataContext = _vm;
 
-            _vm.Profiles = _proxy.GetProfiles().ToList();
+            var list = _proxy.GetProfiles();
+            if (list == null)
+            {
+                list = new List<DualShockProfile>();
+            }
+            else
+            {
+                _vm.Profiles = list.ToList();
+            }
         }
 
         private void ProxyOnNativeFeedReceived(object sender, ScpHidReport report)


### PR DESCRIPTION
This fix takes care of the nullpointer exception in ScpProfiler when ScpService does not have any profile loaded.