### PR TITLE
Correct Slider Display Value

### DIFF
--- a/ScpControl/Properties/Settings.Designer.cs
+++ b/ScpControl/Properties/Settings.Designer.cs
@@ -136,12 +136,12 @@ namespace ScpControl.Properties {
         [global::System.Configuration.SettingsProviderAttribute(typeof(ScpControl.Utilities.PortableSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("600000")]
-        public int IdleTimout {
+        public int IdleTimeout {
             get {
-                return ((int)(this["IdleTimout"]));
+                return ((int)(this["IdleTimeout"]));
             }
             set {
-                this["IdleTimout"] = value;
+                this["IdleTimeout"] = value;
             }
         }
         

--- a/ScpControl/Properties/Settings.settings
+++ b/ScpControl/Properties/Settings.settings
@@ -29,7 +29,7 @@
     <Setting Name="DisableSecureSimplePairing" Provider="ScpControl.Utilities.PortableSettingsProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="IdleTimout" Provider="ScpControl.Utilities.PortableSettingsProvider" Type="System.Int32" Scope="User">
+    <Setting Name="IdleTimeout" Provider="ScpControl.Utilities.PortableSettingsProvider" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">600000</Value>
     </Setting>
     <Setting Name="Ds3RumbleLatency" Provider="ScpControl.Utilities.PortableSettingsProvider" Type="System.Int32" Scope="User">

--- a/ScpControl/ScpCore/GlobalConfiguration.cs
+++ b/ScpControl/ScpCore/GlobalConfiguration.cs
@@ -135,13 +135,13 @@ namespace ScpControl.ScpCore
 
         public bool IdleDisconnect
         {
-            get { return Settings.Default.IdleTimout != 0; }
+            get { return Settings.Default.IdleTimeout != 0; }
         }
 
         public int IdleTimeout
         {
-            get { return Settings.Default.IdleTimout; }
-            set { Settings.Default.IdleTimout = value; }
+            get { return Settings.Default.IdleTimeout; }
+            set { Settings.Default.IdleTimeout = value; }
         }
 
         public int Latency

--- a/ScpControl/app.config
+++ b/ScpControl/app.config
@@ -45,7 +45,7 @@
       <setting name="DisableSecureSimplePairing" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="IdleTimout" serializeAs="String">
+      <setting name="IdleTimeout" serializeAs="String">
         <value>600000</value>
       </setting>
       <setting name="Ds3RumbleLatency" serializeAs="String">

--- a/ScpServer/App.config
+++ b/ScpServer/App.config
@@ -93,7 +93,7 @@
       <setting name="DisableSecureSimplePairing" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="IdleTimout" serializeAs="String">
+      <setting name="IdleTimeout" serializeAs="String">
         <value>600000</value>
       </setting>
       <setting name="Ds3RumbleLatency" serializeAs="String">

--- a/ScpSettings/MainWindow.xaml
+++ b/ScpSettings/MainWindow.xaml
@@ -120,7 +120,7 @@
 
                         <!-- Idle Timeout -->
                         <GroupBox Header="Idle Timeout: 10 minutes"
-                                  x:Name="IdleTimoutGroupBox"
+                                  x:Name="IdleTimeoutGroupBox"
                                   Grid.Row="2">
                             <StackPanel>
                                 <TextBlock>
@@ -128,7 +128,8 @@
                                 </TextBlock>
                                 <Slider Maximum="30"
                                         Value="{Binding Path=IdleTimeout}"
-                                        ValueChanged="IdleTimoutSlider_ValueChanged"
+                                        ValueChanged="IdleTimeoutSlider_ValueChanged"
+                                        Name= "IdleTimeoutSlider"
                                         LargeChange="5" SmallChange="1" />
                             </StackPanel>
                         </GroupBox>
@@ -184,7 +185,9 @@
                                     Defines the minimal duration the rumble request will be sent to the controller until it stops.
                                 </TextBlock>
                                 <Slider LargeChange="1" Maximum="16"
-                                        Value="{Binding Path=Latency}" ValueChanged="Slider_ValueChanged" />
+                                        Value="{Binding Path=Latency}"
+                                        ValueChanged="RumbleLatencySlider_ValueChanged"
+                                        Name= "RumbleLatencySlider" />
                             </StackPanel>
                         </GroupBox>
 
@@ -215,7 +218,8 @@
                                             IsSnapToTickEnabled="True"
                                             VerticalAlignment="Center"
                                             Value="{Binding Path=Ds3LEDsPeriod}"
-                                            ValueChanged="Slider_LEDsPeriodChanged" />
+                                            ValueChanged="LEDsFlashingPeriodSlider_ValueChanged"
+                                            Name= "LEDsFlashingPeriodSlider" />
 
                                     <!-- Maximum value -->
                                     <Label Grid.Column="2">
@@ -335,7 +339,8 @@
                         <StackPanel>
                             <Slider Maximum="255"
                                     Value="{Binding Path=Brightness}" LargeChange="16"
-                                    ValueChanged="BrightnessSlider_ValueChanged" SmallChange="1" />
+                                    ValueChanged="BrightnessSlider_ValueChanged" SmallChange="1"
+                                    Name="BrightnessSlider" />
                             <TextBlock>
                                 Hint: move the slider all the way to the left to disable the Light Bar entirely.
                             </TextBlock>

--- a/ScpSettings/MainWindow.xaml.cs
+++ b/ScpSettings/MainWindow.xaml.cs
@@ -72,23 +72,29 @@ namespace ScpSettings
 
             DataContext = null;
             DataContext = _config;
+
+            // Invoke Slider EventHandlers To Correctly Display GroupBox Headers
+            IdleTimeoutSlider_ValueChanged(sender, new RoutedPropertyChangedEventArgs<double> (0, IdleTimeoutSlider.Value));
+            RumbleLatencySlider_ValueChanged(sender, new RoutedPropertyChangedEventArgs<double> (0, RumbleLatencySlider.Value));
+            LEDsFlashingPeriodSlider_ValueChanged(sender, new RoutedPropertyChangedEventArgs<double> (0, LEDsFlashingPeriodSlider.Value));
+            BrightnessSlider_ValueChanged(sender, new RoutedPropertyChangedEventArgs<double> (0, BrightnessSlider.Value));
         }
 
-        private void IdleTimoutSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void IdleTimeoutSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             var value = e.NewValue;
 
             if (value == 0)
             {
-                IdleTimoutGroupBox.Header = "Idle Timeout: Disabled";
+                IdleTimeoutGroupBox.Header = "Idle Timeout: Disabled";
             }
             else if (value == 1)
             {
-                IdleTimoutGroupBox.Header = "Idle Timeout: 1 minute";
+                IdleTimeoutGroupBox.Header = "Idle Timeout: 1 minute";
             }
             else
             {
-                IdleTimoutGroupBox.Header = string.Format("Idle Timeout: {0} minutes", value);
+                IdleTimeoutGroupBox.Header = string.Format("Idle Timeout: {0} minutes", value);
             }
         }
 
@@ -101,14 +107,14 @@ namespace ScpSettings
                 : string.Format("Light Bar Brightness: {0}%", (int)((value * 100) / 255));
         }
 
-        private void Slider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void RumbleLatencySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             var value = ((int)e.NewValue) << 4;
 
             RumbleLatencyGroupBox.Header = string.Format("Rumble Latency: {0} ms", value);
         }
 
-        private void Slider_LEDsPeriodChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void LEDsFlashingPeriodSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             var value = (int)e.NewValue;
 


### PR DESCRIPTION
Address #636

- Invoke slider event handlers after window initialization
- Rename functions for consistency with slider names
- Rectify spelling to 'timeout'